### PR TITLE
修复了bwaves、zeusmp 和 wrf 在生成 checkpoint 时会 Segmentation fault 的 bug

### DIFF
--- a/checkpoint_scripts/generate_bbl.py
+++ b/checkpoint_scripts/generate_bbl.py
@@ -564,6 +564,7 @@ class RootfsBuilder(BaseConfig):
             taskN.append("#!/bin/sh")
             taskN.append("set -x")
             taskN.append(f"echo '===== Start running TASK{i} ====='")
+            taskN.append("ulimit -s unlimited")
             taskN.append("date -R")
             if with_nemu_trap:
                 taskN.append("/spec_common/before_workload")


### PR DESCRIPTION
# NEMU-ERROR-段错误

## 【环境描述】

使用的小机房环境：

> /nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint.sh

```bash
source /nfs/home/share/workload_env/env.sh
export XIANGSHAN_FDT=/nfs/home/share/workload_env/workload_build_env/dts/build/xiangshan.dtb
export GCPT_HOME=/nfs/home/share/workload_env/LibCheckpointAlpha
```

NEMU：34bd2b19bc5735f3e8631354fcf4967f667d731a
LibCheckpointAlpha：a6a7d67b3518f215ce34f2a2efa8ee4c150505c6
checkpoint_scripts：a37557ada022201706b8394bccea923f2413a600
config.yaml：/nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/config/config_all.yaml
**我生成的checkpoint路径：**/nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/checkpoint_scripts/archive/spec06_llvm19.1.0_rv64gcb_peak_pgo_NEMU_archgroup_2024-10-22-16-43

> profiling.err.log：/nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/checkpoint_scripts/archive/spec06_llvm19.1.0_rv64gcb_peak_pgo_NEMU_archgroup_2024-10-22-16-43/logs/profiling-0/bwaves/profiling.err.log
> checkpoint.err.log：/nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/checkpoint_scripts/archive/spec06_llvm19.1.0_rv64gcb_peak_pgo_NEMU_archgroup_2024-10-22-16-43/logs/checkpoint-0-0-0/bwaves/checkpoint.err.log

## 【我的问题】

我在使用小机房环境一键生成 checkpoint 环境为我的 29 个 spec06 的 binary 生成 checkpoint，其中 bwaves、zeusmp 和 wrf 这 3 个 binary 生成过程中出现 `Segmentation fault`

## 【我想要的】

我想让我的 bwaves、zeusmp 和 wrf 这 3 个 binary 能正常生成 checkpoint。

## 【现象描述】

我使用如下命令进行一键 checkpoint ，发现 checkpoint-0-*-0 下 bwaves 和 zeusmp 两个文件夹为空。

```bash
python3 generate_checkpoint.py --config config_all.yaml
```

查看相关日志发现 bwaves 和 zeusmp 的情况是一样的，都是 build 没有问题但是从 profiling 开始出现问题。
下面是 bwaves 的 profiling.err.log 的部分内容，可以看到第 61 行的 “Segmentation fault” ，从 date -R 打印的时间来看几乎是刚执行就出错了。

> bwaves  checkpoint.err.log 也是类似的情况

```bash
===== Start running SPEC2006 =====

======== BEGIN bwaves ========

+ md5sum /spec0/bwaves

f2c76c140006fb7f6d9d9e64e883424f  /spec0/bwaves

+ PID0=27

+ wait 27

+ /bin/busybox taskset -c 0 /spec0/task0.sh

+ echo '===== Start running TASK0 ====='

===== Start running TASK0 =====

+ date -R

Thu, 01 Jan 1970 00:00:02 +0000

+ /spec_common/before_workload

+ cd /spec0

+ ./bwaves

[    3.115473] bwaves[30]: unhandled signal 11 code 0x1 at 0x0000003fca779490 in bwaves[d1a26,4a000+ac000]

[    3.116952] CPU: 0 PID: 30 Comm: bwaves Not tainted 6.10.2 #3

[    3.117750] Hardware name: freechips,rocketchip-unknown (DT)

[    3.118461] epc : 00000000000e2a26 ra : 000000000004ce06 sp : 0000003f9ac2b090

[    3.119319]  gp : 00000000000fd958 tp : 0000000034785760 t0 : 0000000000000008

[    3.120173]  t1 : 000000000000000a t2 : 0000000000000001 s0 : 0000003fcdb0cb10

[    3.121025]  s1 : 00000000000000c8 a0 : 0000003fca779490 a1 : 0000000000000000

[    3.121876]  a2 : 0000000003393200 a3 : 0000003fcdb0c690 a4 : 0000000000000000

[    3.122725]  a5 : 0000003fca779490 a6 : 00000000000ce4c8 a7 : 0000003fca779490

[    3.123566]  s2 : 0000003f9c0cc490 s3 : 0000000003393200 s4 : 0000000000000040

[    3.124448]  s5 : 0000000000000041 s6 : 0000000000000041 s7 : 0000000000000040

[    3.125303]  s8 : 0000000000001081 s9 : 0000000000042040 s10: 0000003f9c0cc4e0

[    3.126359]  s11: 0000003f9ac2b0a0 t3 : 0000003fcdb0cb20 t4 : 0000003fcdb0cb68

[    3.127213]  t5 : 0000000000000000 t6 : 0000000000000064

[    3.127892] status: 8000000200006020 badaddr: 0000003fca779490 cause: 000000000000000f

[    3.128907] Code: 962a 8e1d 5813 0066 0563 0208 1693 0068 88be 96be (e398) e798 

Segmentation fault

+ date -R

Thu, 01 Jan 1970 00:00:02 +0000

+ /spec_common/trap
```

## 【工作流程】

```bash
git clone https://github.com/xyyy1420/checkpoint_scripts.git
cd checkpoint_scripts/checkpoint_scripts
source /nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint.sh
python3 generate_checkpoint.py --config config_all.yaml
```

config_all.yaml 的完整内容如下：

```bash
base_config:
  message: "NULL" # 通常为空
  spec_app_list: "/nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/lst/lst/spec06/all.lst" # 与下面的 spec_apps 选项作用一致，这里填写一个 list 文件的路径，list 文件中每行一个子项
  spec_apps: null # 这里填写用英文逗号分割的子项
  elf_folder: "/nfs/home/qiulei/hb/binary/hebo/spec06/peak/20241016-llvm19.1.0-gcb-rename" # 使用的 elf 的路径
  times: "1,3,1" # profiling cluster checkpoint 各运行的次数
  start_id: "0,0,0" # profiling cluster checkpoint 各运行的结果保存路径的起始 id
  emulator: "NEMU" # 用于 profiling 和 checkpoint 的模拟器，可选 "QEMU" 或者 "NEMU"
  build_bbl_only: false # 设置为 true 时编译完所有的 workload 后结束运行
  max_threads: 70 # profiling cluster checkpoint 时可以使用的最大线程数
  CPU2017: false # 目标 elf 是否是 speccpu2017
  generate_rootfs_script_only: false # 是否仅生成 rootfs 脚本之后停止
  copies: 1 # profiling 和 checkpoint 并行执行多少个 spec 子项，当 copies=1 时 kernel 将放置在 0x80200000，否则 kernel 将放置在 0x80800000
  archive_id: null # 如果设置了 archive_id 将跳过 workload 构建前的阶段，直接使用该 id 下已有的 workload
  redirect_output: false # 是否重定向子项的输出
  cpu_bind: 0 # useless
  mem_bind: 0 # useless
  bootloader: "opensbi" # 使用 opensbi 还是 riscv-pk 作为启动器，riscv-pk 的流程目前维护不佳
  all_in_one_workload: true # 如果使用 all in one workload，将会使用 gcpt 链接 workload，生成的 workload 可以直接被启动，在使用 QEMU 作为模拟器时，必须使用 all in one workload
  boot_for_test: true # 设置为 true 时将在构建完 workload 使用上述配置文件中指定的模拟器运行 1min
archive_id_config: # 配置生成的 archive id，仅影响结果放置在哪里
  gcc_version: "llvm19.1.0"
  riscv_ext: "rv64gcb"
  base_or_fixed: "peak"
  special_flag: "pgo"
  group: "archgroup"
```

## 【我的尝试】

我尝试将 bwaves、zeusmp 和 wrf 这 3 个 binary 用 qemu-riscv64 运行发现也出现 `Segmentation fault` 。

我尝试把 bwaves 在 Spacemit(R) X60 上运行发现也出现 `Segmentation fault` 。

但神奇的是我只要在运行前执行 `ulimit -s unlimited` （将栈大小设为无限制），bwaves 在 Spacemit(R) X60 上就能成功运行，并且运行结果能通过 specdiff。

> 于是乎我用 qemu-riscv64 模拟 bwaves 前也执行 `ulimit -s unlimited` （将栈大小设为无限制），可是结果还是 `Segmentation fault` 。

我去看了 bwaves 的 run.sh，发现没有  `Segmentation fault`  这条指令

> /nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/checkpoint_scripts/archive/spec06_llvm19.1.0_rv64gcb_peak_pgo_NEMU_archgroup_2024-10-22-16-43/scripts/bwaves_task0.sh

```bash
#!/bin/sh
set -x
echo '===== Start running TASK0 ====='
date -R
/spec_common/before_workload
cd /spec0 && ./bwaves   
date -R
/spec_common/trap
```

> 很久以前用 [[auto_checkpoint](https://github.com/xyyy1420/auto_checkpoint)](https://github.com/xyyy1420/auto_checkpoint) 一键 checkpoints 时，生成的 riscv-rootfs/rootfsimg/run.sh 里还带有 `ulimit -s unlimited` 这条命令，但是现在 [[checkpoint_scripts](https://github.com/xyyy1420/checkpoint_scripts)](https://github.com/xyyy1420/checkpoint_scripts) 生成的 run.sh 没有了这条指令。

于是我尝试进行了如下修改（为 run.sh 添加 `ulimit -s unlimited`）：

```bash
diff --git a/checkpoint_scripts/generate_bbl.py b/checkpoint_scripts/generate_bbl.py
index c3858a7..e34366c 100644
--- a/checkpoint_scripts/generate_bbl.py
+++ b/checkpoint_scripts/generate_bbl.py
@@ -180,6 +180,9 @@ class RootfsBuilder(BaseConfig):
             taskN.append("#!/bin/sh")
             taskN.append("set -x")
             taskN.append(f"echo '===== Start running TASK{i} ====='")
+            taskN.append("ulimit -s")
+            taskN.append("ulimit -s unlimited")
+            taskN.append("ulimit -s")
             taskN.append("date -R")
             if with_nemu_trap:
                 taskN.append("/spec_common/before_workload")
```

修改后生成的 run.sh

> /nfs/home/qiulei/hb/TOOL/checkpoint/checkpoint_scripts/checkpoint_scripts/archive/spec06_llvm19.1.0_rv64gcb_peak_pgo_NEMU_410.bwaves_2024-10-30-16-21/scripts/bwaves_task0.sh

```bash
#!/bin/sh
set -x
echo '===== Start running TASK0 ====='
ulimit -s
ulimit -s unlimited
ulimit -s
date -R
/spec_common/before_workload
cd /spec0 && ./bwaves   
date -R
/spec_common/trap
```

Co-authored-by: Chyaka <Chyaka@lilium23187@gmail.com>